### PR TITLE
Fixes

### DIFF
--- a/regole-avanzate/002_nuove_classi_personaggio.md
+++ b/regole-avanzate/002_nuove_classi_personaggio.md
@@ -267,7 +267,7 @@ Gli Illusionisti non possono indossare armature e sono limitati all'uso di pugna
 Gli Illusionisti lanciano incantesimi da mago, ma hanno accesso a più incantesimi (sono trattati come un livello superiore - Capitolo 4 Nuovi Incantesimi).
 
 #### Ammaliamento Minore
-Gli Illusionisti possono alterare il proprio aspetto a volontà, cambiando abito, età, i tratti del viso, il sesso, l'altezza e la corporatura. Non possono apparire di un'altra razza razza e qualcosa del loro aspetto deve rimanere costante -- normalmente la voce, il colore delle loro vesti, l'odore del profumo o una spilla distintiva. L'Illusionista può alterare l'aspetto di qualsiasi cosa tenuta in mano, anche se ritorna al suo vero aspetto quando viene lasciata andare.
+Gli Illusionisti possono alterare il proprio aspetto a volontà, cambiando abito, età, i tratti del viso, il sesso, l'altezza e la corporatura. Non possono apparire di un'altra razza e qualcosa del loro aspetto deve rimanere costante -- normalmente la voce, il colore delle loro vesti, l'odore del profumo o una spilla distintiva. L'Illusionista può alterare l'aspetto di qualsiasi cosa tenuta in mano, anche se ritorna al suo vero aspetto quando viene lasciata andare.
 
 #### Tiro salvezza
 Gli Illusionisti ottengono un bonus di +2 contro illusioni o inganni.

--- a/regole-avanzate/007_esplorazione_avanzata.md
+++ b/regole-avanzate/007_esplorazione_avanzata.md
@@ -152,10 +152,10 @@ Quando viene indicato un incontro, l'Arbitro può determinare il tipo di mostro 
 | Tiro d20 | Pianura                 | Bosco                       | Giungla                       |
 |----------|-------------------------|-----------------------------|-------------------------------|
 | 1        | Dinosauri, qualsiasi    | Orsi                        | Formiche, giganti             |
-| 2        | Cani                    | Cinghiali, normali/giganti  | Scimmie                       |
+| 2        | Cani                    | Cinghiali, normali/giganti  | Scimmioni                     |
 | 3        | Draghi, qualsiasi       | Centauri                    | Basilischi                    |
 | 4        | Nani                    | Millepiedi, grandi/giganti  | Pipistrelli, normali/giganti  |
-| 5        | Elfi                    | Cacatua                     | Scarabei, giganti             |
+| 5        | Elfi                    | Coccatrici                  | Scarabei, giganti             |
 | 6        | Giganti, collina        | Draghi, verde               | Millepiedi, grandi/giganti    |
 | 7        | Gnoll                   | Driadri                     | Dinosauri, qualsiasi          |
 | 8        | Goblin                  | Elfi                        | Draghi, verde                 |
@@ -163,7 +163,7 @@ Quando viene indicato un incontro, l'Arbitro può determinare il tipo di mostro 
 | 10       | Hobgoblin               | Meduse                      | Coboldi                       |
 | 11       | Cavalli                 | Uomini                      | Sanguisughe, giganti          |
 | 12       | Leoni                   | Personaggi non giocanti     | Uomini lucertola              |
-| 13       | Licantropi              | Orchetti                    | Lucertole, grandi/ giganti    |
+| 13       | Licantropi              | Orchetti                    | Lucertole, grandi/giganti     |
 | 14       | Mastodonti              | Pixie                       | Meduse                        |
 | 15       | Uomini                  | Vermi viola                 | Uomini                        |
 | 16       | Personaggi non giocanti | Serpenti, grandi/giganti    | Personaggi non giocanti       |
@@ -176,7 +176,7 @@ Quando viene indicato un incontro, l'Arbitro può determinare il tipo di mostro 
 | Tiro d20 | Montagna                   | Deserto                     | Artico                     |
 |----------|----------------------------|-----------------------------|----------------------------|
 | 1        | Orsi delle caverne         | Formiche, giganti           | Orsi delle caverne         |
-| 2        | Uomini delle caverne       | Uomini delle caverne        | Uomini delle caverne       |
+| 2        | Cavernicoli                | Cavernicoli                 | Cavernicoli                |
 | 3        | Chimere                    | Millepiedi, grandi/giganti  | Ciclopi                    |
 | 4        | Draghi, rosso              | Chimere                     | Cani                       |
 | 5        | Nani                       | Ciclopi                     | Draghi, bianchi            |
@@ -190,8 +190,8 @@ Quando viene indicato un incontro, l'Arbitro può determinare il tipo di mostro 
 | 13       | Leoni, maculati            | Manticore                   | Personaggi non giocanti    |
 | 14       | Uomini                     | Uomini                      | Vermi viola                |
 | 15       | Minotauri                  | Mummie                      | Tigri dai denti a sciabola |
-| 16       | Personaggi non giocanti    | Personaggi non giocanti     | Teschi                     |
-| 17       | Rocs                       | Vermi viola                 | Lupi                       |
+| 16       | Personaggi non giocanti    | Personaggi non giocanti     | Thull                      |
+| 17       | Roc                        | Vermi viola                 | Lupi                       |
 | 18       | Tigri dai denti a sciabola | Salamandre                  | Lupi, giganti              |
 | 19       | Troll                      | Scorpioni, giganti          | Mammut lanosi              |
 | 20       | Viverne                    | Serpenti, grandi            | Rinoceronti lanosi         |
@@ -199,14 +199,14 @@ Quando viene indicato un incontro, l'Arbitro può determinare il tipo di mostro 
 
 | Tiro d20 | Palude                     | Città                   | Necropoli                     |
 |----------|----------------------------|-------------------------|-------------------------------|
-| 1        | Basilischi                 | Uomini delle caverne    | Pipistrelli, normale/giganti  |
+| 1        | Basilischi                 | Cavernicoli             | Pipistrelli, normali/giganti  |
 | 2        | Coccodrilli                | Doppelganger            | Millepiedi, grandi/giganti    |
 | 3        | Coccodrilli, giganti       | Nani                    | Gargoyle                      |
 | 4        | Dinosauri, qualsiasi       | Elfi                    | Ghoul                         |
-| 5        | Draghi tartarughe          | Ghoul                   | Goblin/Hobgoblin              |
+| 5        | Tartarughe drago           | Ghoul                   | Goblin/Hobgoblin              |
 | 6        | Draghi, nero               | Giganti, qualsiasi      | Golem, qualsiasi              |
 | 7        | Giganti, collina           | Gnoll                   | Manticore                     |
-| 8        | Idre                       | Goblin                  | Uomini, zelanti               |
+| 8        | Idre                       | Goblin                  | Uomini, zeloti                |
 | 9        | Coboldi                    | Golem, qualsiasi        | Mummie                        |
 | 10       | Sanguisughe, giganti       | Halfling                | Personaggi non giocanti       |
 | 11       | Uomini lucertola           | Hobgoblin               | Ratti, giganti                |
@@ -215,7 +215,7 @@ Quando viene indicato un incontro, l'Arbitro può determinare il tipo di mostro 
 | 14       | Uomini                     | Uomini, dervisci        | Spettri                       |
 | 15       | Personaggi non giocanti    | Personaggi non giocanti | Ragni, grandi/giganti         |
 | 16       | Melme, qualsiasi           | Orchi                   | Vampiri                       |
-| 17       | Vermi viola                | Orchetti                | Erranti                       |
+| 17       | Vermi viola                | Orchetti                | Anime dannate                 |
 | 18       | Serpenti, grandi/giganti   | Ratti, giganti          | Lupi, giganti                 |
 | 19       | Rospi, giganti             | Titano                  | Apparizioni                   |
 | 20       | Troll                      | Vampiri                 | Zombie                        |
@@ -381,8 +381,8 @@ Quando viene determinato un incontro, stabilite il tipo di mostro tirando i dadi
 | 13       | Uomini, pirati          | Uomini lucertola        | Tritoni                 |
 | 14       | Tritoni                 | Uomini                  | Nixie                   |
 | 15       | Nixie                   | Uomini, bucanieri       | Personaggi non giocanti |
-| 16       | Personaggi non giocanti | Uomini, pirati          | Polpi, giganti          |
-| 17       | Polpi giganti           | Tritoni                 | Serpenti marini         |
+| 16       | Personaggi non giocanti | Uomini, pirati          | Piovre, giganti         |
+| 17       | Piovre, giganti         | Tritoni                 | Serpenti marini         |
 | 18       | Serpenti marini         | Nixie                   | Serpenti marini         |
 | 19       | Serpente, giganti       | Nixie                   | Serpente, giganti       |
 | 20       | Rospi, giganti          | Personaggi non giocanti | Calamari, giganti       |
@@ -524,8 +524,8 @@ Quando si verifica un incontro, determinate il tipo di mostro tirando i dadi sul
 
 | Tiro d20 | Cime delle montagne      | Cielo aperto             | Cime delle nuvole        |
 |----------|--------------------------|--------------------------|--------------------------|
-| 1        | Uomini delle caverne     | Chimere                  | Chimere                  |
-| 2        | Chimere                  | Dinosauri, pterodattili  | Cacatua                  |
+| 1        | Cavernicoli              | Chimere                  | Chimere                  |
+| 2        | Chimere                  | Dinosauri, pterodattili  | Coccatrici               |
 | 3        | Coccatrici               | Dinosauri, pterodattili‡ | Dinosauri, pterodattili† |
 | 4        | Dinosauri, pterodattili† | Djinn                    | Djinn                    |
 | 5        | Draghi, bianco           | Draghi, qualsiasi        | Draghi, dorato           |

--- a/regole-avanzate/008_mostri_aggiuntivi.md
+++ b/regole-avanzate/008_mostri_aggiuntivi.md
@@ -434,7 +434,7 @@ I ragni, giganti e grandi, sono comuni nei sotterranei. I ragni grandi hanno le 
 *Classe Armatura*: 7 [12]  
 *Dadi Vita*: ½  
 *Attacchi*: Morso (vedi sotto)  
-*Speciale*: Ragnatela   
+*Speciale*: Malattia (vedi sotto)   
 *Movimento*: 12/6  
 *DVE/PE*: 2/30
 

--- a/regole-avanzate/012_strumenti_arbitro.md
+++ b/regole-avanzate/012_strumenti_arbitro.md
@@ -128,7 +128,7 @@ Usa questa tabella per progettare trappole. Sarà necessario impiegare un po' di
 <sup>1</sup> Avvelenato con un tiro di 1 su d10
 <sup>2</sup> Tirate un d10; punte avvelenate, 1; punte, 2-3; allagamento, 4
 <sup>3</sup> Tirate un d10; trappola, 1-2; ago avvelenato, 3
-<sup>4</sup> Tirate un d10; accecante, 1-2; confusione, 3-4; paura, 5; velenoso, 6; sonno, 7-8; rallentamento, 9-10;
+<sup>4</sup> Tirate un d10; accecante, 1-2; confusione, 3-4; paura, 5; velenoso, 6; sonno, 7-8; rallentamento, 9-10
 <sup>5</sup> Tirate un d6; blocca il passaggio davanti 1-3; blocca il passaggio dietro 4-6
 <sup>6</sup> Tirate un d10; inondazione, 1-2; ascensore, 3-4; collasso, 5-6; spunzoni, 7-8; schiacciante, 9-10
 
@@ -349,7 +349,7 @@ Usate la tabella qui sotto per determinare a caso il contenuto di barattoli, vas
 | 25-27 | Uova, esotiche in salamoia | 77-79 | Sale, cristalli         |
 | 28-31 | Viscere, sottaceto         | 80-82 | Semi                    |
 | 32-35 | Occhi, secchi              | 83-85 | Torsolo                 |
-| 36-38 | Grasso/grasso              | 86-88 | Pelle, secca            |
+| 36-38 | Grasso/lardo               | 86-88 | Pelle, secca            |
 | 39-41 | Dita/piedi, secchi         | 89-91 | Bava                    |
 | 42-44 | Petali di fiori, secchi    | 92-94 | Denti                   |
 | 45-47 | Fluido, putrido            | 95-97 | Lingua, sottaceto       |

--- a/regole-base/capitolo7-condurre-il-gioco.md
+++ b/regole-base/capitolo7-condurre-il-gioco.md
@@ -183,7 +183,7 @@ Per la classe dei personaggi incontrati, tirare un d6 per il loro allineamento: 
 |   9  |  Demone, Succube  |     Elementale, Fuoco    | Guerriero, livello 9 |   Elementale, Acqua   |
 |  10  |     Salamandra    |     Elementale, Acqua    |  Chierico, livello 9 | Cavaliere della Morte |
 |  11  |      Viverna      |          Gorgone         |    Mago, livello 8   |    Lumaca, Gigante    |
-|  12  |      Dijinni      |  Inseguitore Invisibile  |   Ladro, livello 9   |      Verme Viola      |
+|  12  |      Djinni       |  Inseguitore Invisibile  |   Ladro, livello 9   |      Verme Viola      |
 
 
 ### Tabelle degli Incontri nelle Terre Selvagge per Tipo di Terreno
@@ -271,11 +271,11 @@ Per la classe dei personaggi incontrati, tirare un d6 per il loro allineamento: 
 | Tirare |     Drago     |       Non-Morto       |      Gigante      |
 |:------:|:-------------:|:---------------------:|:-----------------:|
 |    1   |   Drago, Oro  |        Banshee        |      Efreeti      |
-|    2   |   Drago, Blu  |      Apparizione      |      Dijinni      |
-|    3   |  Drago, Nero  |         Ombra         | Gigante, Ghiaccio |
+|    2   |   Drago, Blu  |      Apparizione      |      Djinni       |
+|    3   |  Drago, Nero  |         Ombra         |   Gigante, Gelo   |
 |    4   |  Drago, Verde |         Ghoul         |  Gigante, Pietra  |
-|    5   |  Drago, Rosso |       Scheletri       |  Gigante, Colline |
-|    6   | Drago, Bianco |         Zombie        | Gigante, Tempeste |
+|    5   |  Drago, Rosso |       Scheletri       |  Gigante, Collina |
+|    6   | Drago, Bianco |         Zombie        | Gigante, Tempesta |
 |    7   |    Viverne    |     Anima Dannata     |   Gigante, Fuoco  |
 |    8   |      Idra     |         Mummie        |  Gigante, Nuvole  |
 |    9   |       —      |        Spettro        |  Gigante, Firbolg |

--- a/regole-base/capitolo8-mostri.md
+++ b/regole-base/capitolo8-mostri.md
@@ -97,7 +97,7 @@ Le anime dannate vivono in tombe, cimiteri e tumuli. Sono non-morti e quindi non
 *Movimento*: 24  
 *DVE/PE*: 6/400
 
-Le apparizioni sono delle potenti anime dannate, immuni a tutte le armi non magiche tranne quelle d'argento (che infliggono solo metà del danno). Le frecce sono particolarmente inefficaci contro di loro e perfino le frecce magiche e d'argento infliggono solo un punto di danno per colpo. Le apparizioni possono montare cavalli da battaglia ben addestrati o cavalcature più insolite che tollerano la loro presenza.
+Le apparizioni sono delle potenti anime dannate, immuni a tutte le armi non magiche tranne quelle d'argento (che infliggono solo metà del danno). Le frecce sono particolarmente inefficaci contro di loro e perfino le frecce magiche e d'argento infliggono solo un punto di danno per colpo. Il tocco dell'apparizione drena un livello alla vittima. Le apparizioni possono montare cavalli da battaglia ben addestrati o cavalcature più insolite che tollerano la loro presenza.
 
 ### Arpia
 
@@ -719,7 +719,7 @@ Che siano fatti di vetro colorato animato o di enormi pile di frammenti frastagl
 
 *Classe Armatura*: 2 [17]  
 *Dadi Vita*: 8  
-*Attacchi*: Gore (1d6+1)  
+*Attacchi*: Incornata (1d6+1)  
 *Speciale*: Soffio di pietra  
 *Movimento*: 12  
 *DVE/PE*: 10/1,400
@@ -908,7 +908,7 @@ Le mummie non possono essere colpite da armi normali e anche le armi magiche inf
 
 La melma grigia è quasi identica alla roccia bagnata, ma è una sostanza viscida e informe che divora prede e carogne con le sue secrezioni acide, sferzando in avanti per colpire i nemici. La melma grigia è immune agli incantesimi, al calore e ai danni da freddo. Il metallo (ma non la pietra o il legno) deve effettuare un tiro salvezza contro l'acido quando viene esposto alla melma grigia (anche se il contatto è breve come il colpo di una spada) o marcisce. Quando la melma grigia colpisce un personaggio con un'armatura di metallo, l'armatura deve effettuare un tiro salvezza contro gli oggetti. Solo il taglio e la perforazione danneggiano la melma grigia, che è impenetrabile agli attacchi contundenti o di schiacciamento.
 
-### Melma verde
+### Melma Verde
 
 La melma verde non è tecnicamente un mostro, solo un rischio estremamente pericoloso nelle tombe sotterranee e altri luoghi simili. Qualsiasi sostanza metallica o organica che tocca inizia a trasformarsi in melma verde (tiro salvezza). Può essere uccisa con il fuoco o con il freddo estremo, e il processo di trasformazione può essere arrestato con l'uso dell'incantesimo Curare le Malattie.
 
@@ -1170,7 +1170,7 @@ Questi minuscoli uccelli hanno becchi simili ad aghi che usano per infilzare le 
 *Classe Armatura*: 2 [17]  
 *Dadi Vita*: 7-12  
 *Attacchi*: Colpo  
-*Speciale*: Alberi di controllo  
+*Speciale*: Controllo degli alberi 
 *Movimento*: 6  
 *DVE/PE*: 7/600; 8/800; 9/1,100;  
 10/1,400; 11/1,700; 12/2,000


### PR DESCRIPTION
Alcuni fix di forma per la scatola bianca e le regole avanzate. Lascio qui una lista di bug presenti nel PDF finale e non nei file markdown:

La Scatola Bianca
-  Il titolo "Umano, Bandito" è ripetuto due volte - Uno di loro è in realta Umano, Berserker
- Nell'incantesimo "Animare Cadaveri", il "Raggio d'Azione" e la "Durata" hanno i valori invertiti. Sono corretti nel markdown
- Nelle "Tabelle di Riferimento", alla fine del PDF, la "Tabella della lealtà dei PNG" e' presente due volte